### PR TITLE
Add DevIconMdx to white.lua

### DIFF
--- a/lua/devicon-colorscheme/devicons/white.lua
+++ b/lua/devicon-colorscheme/devicons/white.lua
@@ -6,6 +6,7 @@ function M.get_highlights()
         "DevIconLog",
         "DevIconLock",
         "DeviconMd",
+        "DevIconMdx",
         "DeviconYml",
         "DeviconYaml",
         "DeviconConf",


### PR DESCRIPTION
Noticed that the Mdx filetype wasn't getting picked up by this plugin and it seemed simple enough to add 🙂

Here's a screenshot of the Highlight group I'm adding (just to confirm I haven't made a typo):

<img width="783" alt="Screenshot 2024-08-18 at 9 47 16 PM" src="https://github.com/user-attachments/assets/3e37d00b-7728-4de5-b17b-a3f4e53d5ef4">

